### PR TITLE
Enhance formatting, add colors & skip function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .*.swp
+node_modules

--- a/Readme.md
+++ b/Readme.md
@@ -1,26 +1,22 @@
 # tst
 
-A function for running tests.
+A function for running tests, forward-compatible with [tap]().
 
 [![npm install tst](https://nodei.co/npm/tst.png?mini=true)](https://npmjs.org/package/tst/)
 
 ```js
 // ./test/index.js
-var tst = require('tst'),
+var test = require('tst'),
     assert = require('assert');
 
-tst('A very simple test', function() {
+test('A very simple test', function() {
     var success = true;
     assert.ok(success);
 });
+
+test.skip('Another test', function () {
+
+});
 ```
 
-```sh
-$ node test.js
-```
-
-Or
-
-```sh
-$ beefy test.js
-```
+Run in node: `$ node test.js` or in browser `beefy test.js`.

--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,4 @@
-# tst
-
-A function for running tests, [tap](https://npmjs.org/package/tap)-compatible.
+A function for running tests.
 
 [![npm install tst](https://nodei.co/npm/tst.png?mini=true)](https://npmjs.org/package/tst/)
 

--- a/Readme.md
+++ b/Readme.md
@@ -18,7 +18,7 @@ test.skip('Another test', function () {
 });
 ```
 
-Run in node: `$ node test.js` or in browser `beefy test.js`.
+Run in node: `$ node test.js` or in browser `$ beefy test.js`.
 
 
 ### Related

--- a/Readme.md
+++ b/Readme.md
@@ -5,15 +5,19 @@ A function for running tests.
 ```js
 // ./test.js
 
-var test = require('tst'),
-    assert = require('assert');
+var test = require('tst');
+var assert = require('assert');
+
+//Uncomment this to run inclusive test mode
+//test.only();
 
 test('A very simple test', function() {
     var success = true;
     assert.ok(success);
 });
 
-test.skip('Another test', function () {
+//Exclusive test
+test.skip('Skipped test', function () {
 
 });
 
@@ -21,6 +25,11 @@ test(function () {
 	test('Nested test', function () {
 
 	});
+});
+
+//Inclusive test
+test.only(function () {
+
 });
 ```
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # tst
 
-A function for running tests, forward-compatible with [tap]().
+A function for running tests, [tap](https://npmjs.org/package/tap)-compatible.
 
 [![npm install tst](https://nodei.co/npm/tst.png?mini=true)](https://npmjs.org/package/tst/)
 
@@ -20,3 +20,11 @@ test.skip('Another test', function () {
 ```
 
 Run in node: `$ node test.js` or in browser `beefy test.js`.
+
+
+### Related
+
+> [ava](https://npmjs.org/package/ava) — futuristic test runner by @sindresohrus.<br/>
+> [mocha](https://npmjs.org/package/mocha) — vintage test runner by @tj.<br/>
+> [tape](https://npmjs.org/package/tape) — Test Anything Protocol by @substack.<br/>
+> [tap](https://npmjs.org/package/tap) — Test Anything Protocol by @isaacs<br/>

--- a/Readme.md
+++ b/Readme.md
@@ -3,7 +3,8 @@ A function for running tests.
 [![npm install tst](https://nodei.co/npm/tst.png?mini=true)](https://npmjs.org/package/tst/)
 
 ```js
-// ./test/index.js
+// ./test.js
+
 var test = require('tst'),
     assert = require('assert');
 

--- a/Readme.md
+++ b/Readme.md
@@ -16,6 +16,12 @@ test('A very simple test', function() {
 test.skip('Another test', function () {
 
 });
+
+test(function () {
+	test('Nested test', function () {
+
+	});
+});
 ```
 
 Run in node: `$ node test.js` or in browser `$ beefy test.js`.

--- a/Readme.md
+++ b/Readme.md
@@ -1,18 +1,26 @@
 # tst
 
-A CommonJS module exporting a function for running tests.
+A function for running tests.
 
-e.g.
+[![npm install tst](https://nodei.co/npm/tst.png?mini=true)](https://npmjs.org/package/tst/)
 
-    // ./test/index.js
-    var tst = require('tst'),
-        assert = require('assert');
+```js
+// ./test/index.js
+var tst = require('tst'),
+    assert = require('assert');
 
-    tst('A very simple test', function() {
-        var success = true;
-        assert.ok(success);
-    });
+tst('A very simple test', function() {
+    var success = true;
+    assert.ok(success);
+});
+```
 
-Run with:
+```sh
+$ node test.js
+```
 
-    node test
+Or
+
+```sh
+$ beefy test.js
+```

--- a/index.js
+++ b/index.js
@@ -163,7 +163,7 @@ function printWarn (test, single) {
         console[single ? 'log' : 'group']('%c~ ' + test.title + '%c' + indent(1) + test.time.toFixed(2) + 'ms', 'color: orange; font-weight: normal', 'color:rgb(150,150,150); font-size:0.9em');
     }
     else {
-        console.log(chalk.yellow(indent(test.indent) + ' ~ ' + test.title), chalk.gray(indent(1) + test.time.toFixed(2) + 'ms'));
+        console.log(chalk.yellow(indent(test.indent) + ' ~ ' + test.title), chalk.dim.gray(indent(1) + test.time.toFixed(2) + 'ms'));
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -6,9 +6,12 @@ var indent = '  ';
 
 function test(message, testFunction) {
     if (!testFunction) {
+        if (typeof message === 'string') return skip(message);
+
         testFunction = message;
-        message = '';
+        message = message.name;
     }
+
     try{
         testFunction.call();
         console.log(chalk.green(indent, '√', message));
@@ -26,8 +29,11 @@ function test(message, testFunction) {
     }
 }
 
-test.skip = function (message, testFunction) {
+function skip (message) {
     console.log(chalk.cyan(indent, '-', message));
 }
+
+
+test.skip = skip;
 
 module.exports = test;

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 var chalk = require('chalk');
 var isBrowser = require('is-browser');
 
-var tab = '    ';
-var indent = '  ';
+var tab = '   ';
+var indent = ' ';
 
 function test(message, testFunction) {
     if (!testFunction) {

--- a/index.js
+++ b/index.js
@@ -13,4 +13,8 @@ function test(message, testFunction) {
     }
 }
 
+test.skip = function (message, testFunction) {
+    console.log('SKIPPED', message);
+}
+
 module.exports = test;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var chalk = require('chalk');
 var isBrowser = require('is-browser');
+var now = require('performance-now');
 
 var INDENT = '  ';
 var indentCount = 0;
@@ -10,6 +11,7 @@ function test(message, testFunction) {
     testCount++;
 
     if (!testFunction) {
+        //If only message - do skip
         if (typeof message === 'string') {
             indentCount--;
 
@@ -26,17 +28,18 @@ function test(message, testFunction) {
         testFunction = message;
         message = message.name;
         if (!message) message = 'Test #' + testCount;
-
     }
 
     try{
+        var time = -now();
         testFunction.call();
+        time += now();
 
         if (isBrowser) {
-            console.log('%c√ ' + message, 'color: green');
+            console.log('%c√ ' + message + '%c' + indent(1) + time.toFixed(2) + 'ms', 'color: green', 'color:rgb(150,150,150); font-size:0.9em');
         }
         else {
-            console.log(chalk.green(indent(indentCount), '√', message));
+            console.log(chalk.green(indent(indentCount), '√', message), chalk.gray(indent(1) + time.toFixed(2) + 'ms'));
         }
     } catch(e) {
 

--- a/index.js
+++ b/index.js
@@ -130,11 +130,11 @@ function print (test) {
 function printError (test) {
     //browser shows errors better
     if (isBrowser) {
-        console.log('%c× ' + test.title, 'color: red');
+        console.group('%c× ' + test.title, 'color: red; font-weight: normal');
         if (test.error && test.error !== true) {
             console.error(test.error);
         }
-        // console.groupEnd();
+        console.groupEnd();
     }
     else {
         console.log(chalk.red(indent(test.indent) + ' × ' + test.title));

--- a/index.js
+++ b/index.js
@@ -93,17 +93,19 @@ function indent (number) {
 
 //universal printer dependent on resolved test
 function print (test) {
+    var single = test.children && test.children.length ? false : true;
+
     if (test.error instanceof Error) {
         printError(test);
     }
     else if (test.error) {
-        printWarn(test);
+        printWarn(test, single);
     }
     else if (test.success) {
-        printSuccess(test);
+        printSuccess(test, single);
     }
     else {
-        printSkip(test);
+        printSkip(test, single);
     }
 
     if (test.children) {
@@ -111,43 +113,45 @@ function print (test) {
             print(test.children[i]);
         }
     }
+
+    if (!single && isBrowser) console.groupEnd();
 }
 
 //print pure red error
 function printError (test) {
     //browser shows errors better
     if (isBrowser) {
-        console.group('%c× ' + test.title, 'color: red');
+        console.log('%c× ' + test.title, 'color: red');
         if (test.error && test.error !== true) {
             console.error(test.error);
         }
-        console.groupEnd();
+        // console.groupEnd();
     }
     else {
         console.log(chalk.red(indent(test.indent), '×', test.title));
 
         //NOTE: node prints e.stack along with e.message
         if (test.error.stack) {
-            var stack = test.error.stack.replace(/^\s*/gm, indent(test.indent + 1) + ' ');
+            var stack = test.error.stack.replace(/^\s*/gm, indent(test.indent) + '   ');
             console.error(chalk.gray(stack));
         }
     }
 }
 
 //print green success
-function printSuccess (test) {
+function printSuccess (test, single) {
     if (isBrowser) {
-        console.log('%c√ ' + test.title + '%c' + indent(1) + test.time.toFixed(2) + 'ms', 'color: green', 'color:rgb(150,150,150); font-size:0.9em');
+        console[single ? 'log' : 'group']('%c√ ' + test.title + '%c  ' + test.time.toFixed(2) + 'ms', 'color: green; font-weight: normal', 'color:rgb(150,150,150); font-size:0.9em');
     }
     else {
-        console.log(chalk.green(indent(test.indent), '√', test.title), chalk.gray(indent(1) + test.time.toFixed(2) + 'ms'));
+        console.log(chalk.green(indent(test.indent), '√', test.title), chalk.gray(' ' + test.time.toFixed(2) + 'ms'));
     }
 }
 
 //print yellow warning (not all tests passed)
-function printWarn (test) {
+function printWarn (test, single) {
     if (isBrowser) {
-        console.log('%c~ ' + test.title + '%c' + indent(1) + test.time.toFixed(2) + 'ms', 'color: yellow', 'color:rgb(150,150,150); font-size:0.9em');
+        console[single ? 'log' : 'group']('%c~ ' + test.title + '%c' + indent(1) + test.time.toFixed(2) + 'ms', 'color: orange; font-weight: normal', 'color:rgb(150,150,150); font-size:0.9em');
     }
     else {
         console.log(chalk.yellow(indent(test.indent), '~', test.title), chalk.gray(indent(1) + test.time.toFixed(2) + 'ms'));
@@ -155,9 +159,9 @@ function printWarn (test) {
 }
 
 //print blue skip
-function printSkip (test) {
+function printSkip (test, single) {
     if (isBrowser) {
-        console.log('%c- ' + test.title, 'color: blue');
+        console[single ? 'log' : 'group']('%c- ' + test.title, 'color: blue');
     }
     else {
         console.log(chalk.cyan(indent(test.indent), '-', test.title));

--- a/index.js
+++ b/index.js
@@ -137,7 +137,7 @@ function printError (test) {
         // console.groupEnd();
     }
     else {
-        console.log(chalk.red(indent(test.indent), '×', test.title));
+        console.log(chalk.red(indent(test.indent) + ' × ' + test.title));
 
         //NOTE: node prints e.stack along with e.message
         if (test.error.stack) {
@@ -153,7 +153,7 @@ function printSuccess (test, single) {
         console[single ? 'log' : 'group']('%c√ ' + test.title + '%c  ' + test.time.toFixed(2) + 'ms', 'color: green; font-weight: normal', 'color:rgb(150,150,150); font-size:0.9em');
     }
     else {
-        console.log(chalk.green(indent(test.indent), '√', test.title), chalk.gray(' ' + test.time.toFixed(2) + 'ms'));
+        console.log(chalk.green(indent(test.indent) + ' √ ' + test.title), chalk.gray(' ' + test.time.toFixed(2) + 'ms'));
     }
 }
 
@@ -163,7 +163,7 @@ function printWarn (test, single) {
         console[single ? 'log' : 'group']('%c~ ' + test.title + '%c' + indent(1) + test.time.toFixed(2) + 'ms', 'color: orange; font-weight: normal', 'color:rgb(150,150,150); font-size:0.9em');
     }
     else {
-        console.log(chalk.yellow(indent(test.indent), '~', test.title), chalk.gray(indent(1) + test.time.toFixed(2) + 'ms'));
+        console.log(chalk.yellow(indent(test.indent) + ' ~ ' + test.title), chalk.gray(indent(1) + test.time.toFixed(2) + 'ms'));
     }
 }
 
@@ -173,7 +173,7 @@ function printSkip (test, single) {
         console[single ? 'log' : 'group']('%c- ' + test.title, 'color: blue');
     }
     else {
-        console.log(chalk.cyan(indent(test.indent), '-', test.title));
+        console.log(chalk.cyan(indent(test.indent) + ' - ' + test.title));
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -2,18 +2,24 @@ var chalk = require('chalk');
 var isBrowser = require('is-browser');
 var now = require('performance-now');
 
-var INDENT = '  ';
-var testCount = 0;
+//default indentation
+test.INDENT = '  ';
+
+//whether we run the only test
+test.ONLY = false;
 
 //chain of nested test calls
 var tests = [];
-
+var testCount = 0;
 
 /**
  * Main test function
  */
 function test (message, testFunction) {
-    var resolve, reject;
+    if (test.ONLY) return;
+
+    //ignore bad args
+    if (!message) return;
 
     //init test object params
     var testObj = {
@@ -88,7 +94,7 @@ function end (testObj) {
 function indent (number) {
     var str = '';
     for (var i = 0; i < number; i++) {
-        str += INDENT;
+        str += test.INDENT;
     }
     return str;
 }
@@ -176,6 +182,13 @@ function printSkip (test, single) {
 test.skip = function skip (message) {
    return test(message);
 };
+
+//half-working only alias
+test.only = function only (message, fn) {
+    test.ONLY = false;
+    test(message, fn);
+    test.ONLY = true;
+}
 
 
 module.exports = test;

--- a/index.js
+++ b/index.js
@@ -4,60 +4,89 @@ var now = require('performance-now');
 
 var INDENT = '  ';
 var indentCount = 0;
+
+//list of current running tests
+var currentTest;
+
+//test ids
 var testCount = 0;
 
-function test(message, testFunction) {
-    indentCount++;
-    testCount++;
+
+function test (message, testFunction) {
+    var resolve, reject;
+
+    //init test object params
+    var testObject = {
+        parent: currentTest,
+        indent: indentCount++,
+        id: testCount++,
+        title: message
+    };
+
 
     if (!testFunction) {
-        //If only message - do skip
+        //if only message passed - do skip
         if (typeof message === 'string') {
             indentCount--;
 
-            if (isBrowser) {
-                console.log('%c- ' + message, 'color: blue');
-            }
-            else {
-                console.log(chalk.cyan(indent(indentCount + 1), '-', message));
-            }
-
-            return;
+            //return resolved promise
+            return Promise.resolve(testObject).then(function (test) {
+                if (isBrowser) {
+                    console.log('%c- ' + test.title, 'color: blue');
+                }
+                else {
+                    console.log(chalk.cyan(indent(test.indent), '-', test.title));
+                }
+            });
         }
 
+        //detect test name
         testFunction = message;
         message = message.name;
-        if (!message) message = 'Test #' + testCount;
+        if (!message) message = 'Test #' + testObject.id;
+
+        //update test title
+        testObject.title = message;
     }
 
-    try{
-        var time = -now();
-        testFunction.call();
-        time += now();
 
-        if (isBrowser) {
-            console.log('%c√ ' + message + '%c' + indent(1) + time.toFixed(2) + 'ms', 'color: green', 'color:rgb(150,150,150); font-size:0.9em');
+    //register formatters
+    return (new Promise(function (resolve, reject) {
+        try{
+            testObject.time = now();
+            testFunction.call(testObject);
+            testObject.time = now() - testObject.time;
+            resolve(testObject);
+        } catch (e) {
+            testObject.error = e;
+            reject(testObject);
         }
-        else {
-            console.log(chalk.green(indent(indentCount), '√', message), chalk.gray(indent(1) + time.toFixed(2) + 'ms'));
-        }
-    } catch(e) {
 
-        //Leave formatting to browser, it shows errors better
-        if (isBrowser) {
-            console.group('%c× ' + message, 'color: red');
-            console.error(e);
-            console.groupEnd();
-        }
-        else {
-            console.log(chalk.red(indent(indentCount), '×', message));
+        indentCount--;
+    })).then(
+        function (test) {
+            if (isBrowser) {
+                console.log('%c√ ' + test.title + '%c' + indent(1) + test.time.toFixed(2) + 'ms', 'color: green', 'color:rgb(150,150,150); font-size:0.9em');
+            }
+            else {
+                console.log(chalk.green(indent(test.indent), '√', test.title), chalk.gray(indent(1) + test.time.toFixed(2) + 'ms'));
+            }
+        },
+        function (test) {
+            //Leave formatting to browser, it shows errors better
+            if (isBrowser) {
+                console.group('%c× ' + test.title, 'color: red');
+                console.error(test.error);
+                console.groupEnd();
+            }
+            else {
+                console.log(chalk.red(indent(test.indent), '×', test.title));
 
-            //NOTE: node prints e.stack along with e.message
-            console.error(chalk.gray(indent(indentCount), e.stack));
+                //NOTE: node prints e.stack along with e.message
+                console.error(chalk.gray(indent(test.indent), test.error.stack));
+            }
         }
-    }
-
-    indentCount--;
+    );
 }
 
 function skip (message) {

--- a/index.js
+++ b/index.js
@@ -153,17 +153,17 @@ function printSuccess (test, single) {
         console[single ? 'log' : 'group']('%c√ ' + test.title + '%c  ' + test.time.toFixed(2) + 'ms', 'color: green; font-weight: normal', 'color:rgb(150,150,150); font-size:0.9em');
     }
     else {
-        console.log(chalk.green(indent(test.indent) + ' √ ' + test.title), chalk.gray(' ' + test.time.toFixed(2) + 'ms'));
+        console.log(chalk.green(indent(test.indent) + ' √ ' + test.title) + chalk.gray(' ' + test.time.toFixed(2) + 'ms'));
     }
 }
 
 //print yellow warning (not all tests passed)
 function printWarn (test, single) {
     if (isBrowser) {
-        console[single ? 'log' : 'group']('%c~ ' + test.title + '%c' + indent(1) + test.time.toFixed(2) + 'ms', 'color: orange; font-weight: normal', 'color:rgb(150,150,150); font-size:0.9em');
+        console[single ? 'log' : 'group']('%c~ ' + test.title + '%c  ' + test.time.toFixed(2) + 'ms', 'color: orange; font-weight: normal', 'color:rgb(150,150,150); font-size:0.9em');
     }
     else {
-        console.log(chalk.yellow(indent(test.indent) + ' ~ ' + test.title), chalk.dim.gray(indent(1) + test.time.toFixed(2) + 'ms'));
+        console.log(chalk.yellow(indent(test.indent) + ' ~ ' + test.title) + chalk.gray('  ' + test.time.toFixed(2) + 'ms'));
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -15,22 +15,35 @@ function test(message, testFunction) {
 
     try{
         testFunction.call();
-        console.log(chalk.green(indent, '%c√', message), 'color: green');
+
+        if (isBrowser) {
+            console.log('%c√ ' + message, 'color: green');
+        }
+        else {
+            console.log(chalk.green(indent, '√', message));
+        }
     } catch(e) {
-        console.log(chalk.red(indent, '%c×', message), 'color: red');
 
         //Leave formatting to browser
         if (isBrowser) {
+            console.group('%c× ' + message, 'color: red');
             console.error(e);
+            console.groupEnd();
         }
         else {
+            console.log(chalk.red(indent, '×', message));
             console.error(chalk.gray(tab, e.message, e.stack));
         }
     }
 }
 
 function skip (message) {
-    console.log(chalk.cyan(indent, '%c-', message), 'color: blue');
+    if (isBrowser) {
+        console.log('%c- ' + message, 'color: blue');
+    }
+    else {
+        console.log(chalk.cyan(indent, '-', message));
+    }
 }
 
 

--- a/index.js
+++ b/index.js
@@ -19,11 +19,10 @@ function test(message, testFunction) {
     } catch(e) {
         console.log(chalk.red(indent, '×', message));
 
-        //Leave formatting errors for browser
+        //Leave formatting to browser
         if (isBrowser) {
             console.error(e);
         }
-        //Node console is not that goof
         else {
             console.error(chalk.gray(tab, e.message, e.stack));
         }

--- a/index.js
+++ b/index.js
@@ -1,3 +1,9 @@
+var chalk = require('chalk');
+var isBrowser = require('is-browser');
+
+var tab = '    ';
+var indent = '  ';
+
 function test(message, testFunction) {
     if (!testFunction) {
         testFunction = message;
@@ -5,16 +11,23 @@ function test(message, testFunction) {
     }
     try{
         testFunction.call();
-        console.log('PASSED', message);
+        console.log(chalk.green(indent, '√', message));
     } catch(e) {
-        console.error('FAILED', message);
-        console.error(e.message);
-        console.error(e.stack);
+        console.log(chalk.red(indent, '×', message));
+
+        //Leave formatting errors for browser
+        if (isBrowser) {
+            console.error(e);
+        }
+        //Node console is not that goof
+        else {
+            console.error(chalk.gray(tab, e.message, e.stack));
+        }
     }
 }
 
 test.skip = function (message, testFunction) {
-    console.log('SKIPPED', message);
+    console.log(chalk.cyan(indent, '-', message));
 }
 
 module.exports = test;

--- a/index.js
+++ b/index.js
@@ -1,16 +1,32 @@
 var chalk = require('chalk');
 var isBrowser = require('is-browser');
 
-var tab = '   ';
-var indent = ' ';
-
+var INDENT = '  ';
+var indentCount = 0;
+var testCount = 0;
 
 function test(message, testFunction) {
+    indentCount++;
+    testCount++;
+
     if (!testFunction) {
-        if (typeof message === 'string') return skip(message);
+        if (typeof message === 'string') {
+            indentCount--;
+
+            if (isBrowser) {
+                console.log('%c- ' + message, 'color: blue');
+            }
+            else {
+                console.log(chalk.cyan(indent(indentCount + 1), '-', message));
+            }
+
+            return;
+        }
 
         testFunction = message;
         message = message.name;
+        if (!message) message = 'Test #' + testCount;
+
     }
 
     try{
@@ -20,30 +36,38 @@ function test(message, testFunction) {
             console.log('%c√ ' + message, 'color: green');
         }
         else {
-            console.log(chalk.green(indent, '√', message));
+            console.log(chalk.green(indent(indentCount), '√', message));
         }
     } catch(e) {
 
-        //Leave formatting to browser
+        //Leave formatting to browser, it shows errors better
         if (isBrowser) {
             console.group('%c× ' + message, 'color: red');
             console.error(e);
             console.groupEnd();
         }
         else {
-            console.log(chalk.red(indent, '×', message));
-            console.error(chalk.gray(tab, e.message, e.stack));
+            console.log(chalk.red(indent(indentCount), '×', message));
+
+            //NOTE: node prints e.stack along with e.message
+            console.error(chalk.gray(indent(indentCount), e.stack));
         }
     }
+
+    indentCount--;
 }
 
 function skip (message) {
-    if (isBrowser) {
-        console.log('%c- ' + message, 'color: blue');
+   return test(message);
+}
+
+//return indentation of a number
+function indent (number) {
+    var str = '';
+    for (var i = 0; i < number; i++) {
+        str += INDENT;
     }
-    else {
-        console.log(chalk.cyan(indent, '-', message));
-    }
+    return str;
 }
 
 

--- a/index.js
+++ b/index.js
@@ -15,9 +15,9 @@ function test(message, testFunction) {
 
     try{
         testFunction.call();
-        console.log(chalk.green(indent, '√', message));
+        console.log(chalk.green(indent, '%c√', message), 'color: green');
     } catch(e) {
-        console.log(chalk.red(indent, '×', message));
+        console.log(chalk.red(indent, '%c×', message), 'color: red');
 
         //Leave formatting to browser
         if (isBrowser) {
@@ -30,7 +30,7 @@ function test(message, testFunction) {
 }
 
 function skip (message) {
-    console.log(chalk.cyan(indent, '-', message));
+    console.log(chalk.cyan(indent, '%c-', message), 'color: blue');
 }
 
 

--- a/index.js
+++ b/index.js
@@ -30,13 +30,7 @@ function test (message, testFunction) {
     if (!testFunction) {
         //if only message passed - do skip
         if (typeof message === 'string') {
-
-            //return resolved promise
-            printSkip(testObj);
-
-            tests.pop();
-
-            return;
+            return end(testObj);
         }
 
         //detect test name
@@ -67,6 +61,18 @@ function test (message, testFunction) {
         testObj.error = e;
     }
 
+    return end(testObj);
+}
+
+
+//skipper
+test.skip = function skip (message) {
+   return test(message);
+};
+
+
+//test ender - prints logs, if needed
+function end (testObj) {
     tests.pop();
 
     //if first level finished - log resolved tests
@@ -74,11 +80,6 @@ function test (message, testFunction) {
         print(testObj);
     }
 }
-
-//skipper
-test.skip = function skip (message) {
-   return test(message);
-};
 
 //return indentation of a number
 function indent (number) {

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var isBrowser = require('is-browser');
 var tab = '   ';
 var indent = ' ';
 
+
 function test(message, testFunction) {
     if (!testFunction) {
         if (typeof message === 'string') return skip(message);

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "url": "https://github.com/grahamlyons/tst/issues"
   },
   "dependencies": {
+    "chalk": "^1.1.1",
     "is-browser": "^2.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
   "license": "BSD",
   "bugs": {
     "url": "https://github.com/grahamlyons/tst/issues"
+  },
+  "dependencies": {
+    "is-browser": "^2.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "chalk": "^1.1.1",
-    "is-browser": "^2.0.1"
+    "is-browser": "^2.0.1",
+    "performance-now": "^0.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
   "keywords": [
     "testing"
   ],
-  "author": "grahamlyons",
+  "author": "grahamlyons <graham@grahamlyons.com>",
+  "contributors": [
+    "Dmitry Yvanow <dfcreative@gmail.com>"
+  ],
   "license": "BSD",
   "bugs": {
     "url": "https://github.com/grahamlyons/tst/issues"

--- a/test/index.js
+++ b/test/index.js
@@ -24,3 +24,11 @@ test('Skipped test 2');
 test(function testAsFunctionName () {
 
 });
+
+test(function () {
+	test('Nested test 1');
+
+	test('Nested test 2', function () {
+
+	});
+})

--- a/test/index.js
+++ b/test/index.js
@@ -8,13 +8,13 @@ test('Successful test', function() {
 });
 
 test('Failed test', function () {
-    xxx;
+    assert.equal(1, 2);
 });
 
-test.skip('Async test', function (done) {
+test.skip('TODO: Async test', function (done) {
 	setTimeout(function () {
 		done();
-	});
+	}, 200);
 });
 
 test.skip('Skipped test', function () {

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,5 @@
-var test = require('../index'),
-    assert = require('assert');
+var test = require('../index');
+var assert = require('assert');
 
 test('Successful test', function() {
     assert.ok(true);

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,8 @@
 var test = require('../index');
 var assert = require('assert');
 
+// test.only();
+
 test('Successful test', function() {
     assert.ok(true);
 });
@@ -41,6 +43,10 @@ test(function NestedTestsContainer () {
 	});
 });
 
-test('Final', function () {
+test.only('Final', function () {
+
+});
+
+test('After-party', function () {
 
 });

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,27 @@
-var tst = require('../index'),
+var test = require('../index'),
     assert = require('assert');
 
-tst('A successful test', function() {
+test('Successful test', function() {
     assert.ok(true);
+});
+
+test('Failed test', function () {
+    xxx;
+});
+
+test('Async test', function () {
+
+});
+
+test.skip('Skipped test', function () {
+
+});
+
+test('Skipped test 2');
+
+
+test('Nested test', function () {
+	test('Nestee', function () {
+
+	});
 });

--- a/test/index.js
+++ b/test/index.js
@@ -25,7 +25,7 @@ test(function testAsFunctionName () {
 
 });
 
-test(function () {
+test(function NestedTestsContainer () {
 	test('Nested test 1');
 
 	test('Nested test 2', function () {

--- a/test/index.js
+++ b/test/index.js
@@ -36,7 +36,11 @@ test(function NestedTestsContainer () {
 	});
 	test('Nested test 4', function () {
 		test('Double nested test', function () {
-			xxx;
+			throw Error('xxx');
 		});
 	});
-})
+});
+
+test('Final', function () {
+
+});

--- a/test/index.js
+++ b/test/index.js
@@ -9,8 +9,10 @@ test('Failed test', function () {
     xxx;
 });
 
-test('Async test', function () {
-
+test.skip('Async test', function (done) {
+	setTimeout(function () {
+		done();
+	});
 });
 
 test.skip('Skipped test', function () {
@@ -21,11 +23,4 @@ test('Skipped test 2');
 
 test(function testAsFunctionName () {
 
-});
-
-
-test('Nested test', function () {
-	test('Nestee', function () {
-
-	});
 });

--- a/test/index.js
+++ b/test/index.js
@@ -19,6 +19,10 @@ test.skip('Skipped test', function () {
 
 test('Skipped test 2');
 
+test(function testAsFunctionName () {
+
+});
+
 
 test('Nested test', function () {
 	test('Nestee', function () {

--- a/test/index.js
+++ b/test/index.js
@@ -21,7 +21,7 @@ test.skip('Skipped test', function () {
 
 test('Skipped test 2');
 
-test(function testAsFunctionName () {
+test(function () {
 
 });
 
@@ -30,5 +30,13 @@ test(function NestedTestsContainer () {
 
 	test('Nested test 2', function () {
 
+	});
+	test('Nested test 3', function () {
+		xxx;
+	});
+	test('Nested test 4', function () {
+		test('Double nested test', function () {
+			xxx;
+		});
 	});
 })

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,3 @@
+* nested tests, rendered as groups
+* .only function
+* fix double-error thrown

--- a/todo.md
+++ b/todo.md
@@ -1,3 +1,0 @@
-* nested tests, rendered as groups
-* .only function
-* fix double-error thrown


### PR DESCRIPTION
Hi!
So the first PR enhances formatting, keeping all the tool synchronous.
That turns out that making async tests or `test.only` is tricky.

Before:
![image](https://cloud.githubusercontent.com/assets/300067/12060771/90dd87fc-af44-11e5-89fc-4797759eb566.png)

After:
![image](https://cloud.githubusercontent.com/assets/300067/12060750/573e8a00-af44-11e5-83f6-976b4a505666.png)

In OSX, suppose, it looks even better.
